### PR TITLE
Remove unnecessary string interpolation

### DIFF
--- a/providers/extract.rb
+++ b/providers/extract.rb
@@ -51,7 +51,7 @@ action :extract do
   end
 
   execute "extract #{basename}" do
-    flags = "#{r.tar_flags ? r.tar_flags.join(' ') : '' }"
+    flags = r.tar_flags ? r.tar_flags.join(' ') : ''
     command "tar xfz #{local_archive} #{flags}"
     cwd r.target_dir
     creates r.creates

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -39,7 +39,7 @@ action :install do
   end
 
   execute "compile & install #{dirname}" do
-    flags = (r.prefix ? "--prefix=#{r.prefix}" : '') + "#{r.configure_flags.join(' ')}"
+    flags = (r.prefix ? "--prefix=#{r.prefix}" : '') + r.configure_flags.join(' ')
     command "./configure --quiet #{flags} && make --quiet && make --quiet install"
     cwd "#{src_dir}/#{dirname}"
     creates r.creates


### PR DESCRIPTION
It's a unnecessary string interpolation and causes foodcritic to complain:

```
    FC002: Avoid string interpolation where not required: cookbooks/tar/providers/extract.rb:54
    FC002: Avoid string interpolation where not required: cookbooks/tar/providers/package.rb:42
```

See also: http://acrmp.github.io/foodcritic/#FC002
