### PR TITLE
Fix tar_extract notifications

### DIFF
--- a/providers/extract.rb
+++ b/providers/extract.rb
@@ -23,6 +23,8 @@
 # limitations under the License.
 #
 
+use_inline_resources if defined?(use_inline_resources)
+
 action :extract do
   r = new_resource
   basename = ::File.basename(r.name)
@@ -37,6 +39,7 @@ action :extract do
     group  r.group
     owner  r.user
     mode   r.mode
+    notifies :run, "execute[extract #{basename}]"
   end
 
   execute "extract #{basename}" do

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+use_inline_resources if defined?(use_inline_resources)
+
 action :install do
   r = new_resource
   basename = ::File.basename(r.name)


### PR DESCRIPTION
In order to allow other resources to get notified in case of an tar
extraction, the `updated` flag needs to be set correctly. This is only possible
in Chef >= 11.x by using inline resources.
