### PR TITLE
Reduce tar extractions

### DIFF
--- a/providers/extract.rb
+++ b/providers/extract.rb
@@ -49,5 +49,6 @@ action :extract do
     creates r.creates
     group  r.group
     user   r.user
+    action (r.creates || r.not_if.any? || r.only_if.any? ? :run : :nothing)
   end
 end


### PR DESCRIPTION
With this change, the tar_extract resouce won't extract a tarball during
every chef run, as log as it doesn't get triggered explicitly by a new
or updated remote file.

In case any of the available guards "creates", "not_if" or "only_if" are
present, the behavior depends on the result of the guards.

This change allows to use the following tar_extract resource, which will
make sure that every changed remote file will result in a tar extract
run while it also prevents unnecessary tar extracts in case nothing has
changed.

```
tar_extract "http://files.example.com/foo-#{version}.tar.gz" do
  notifies :restart, "service[foo-service]"
end
```

Using "creates" here doesn't work, as the extracted binary doesn't
include any version string. If the execute resource is running every
time, the notification would trigger too often.
