### PR TITLE
Fixing missing space between prefix value and configure flags.

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -42,7 +42,7 @@ action :install do
   end
 
   execute "compile & install #{dirname}" do
-    flags = (r.prefix ? "--prefix=#{r.prefix}" : '') + r.configure_flags.join(' ')
+    flags = [r.prefix ? "--prefix=#{r.prefix}" : nil, *r.configure_flags].compact.join(' ')
     command "./configure --quiet #{flags} && make --quiet && make --quiet install"
     cwd "#{src_dir}/#{dirname}"
     creates r.creates


### PR DESCRIPTION
When specifying a prefix value in addition to configure flags, there was a missing space and thus the prefix and first configure flag argument became one argument and caused errors.
