### PR TITLE
making tar backward compatible 0.1.0 with 0.0.4 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,4 +3,4 @@ maintainer_email "sysadmin@cramerdev.com"
 license           "Apache 2.0"
 description      "Installs tar and two LWRPs to manage remote tar packages"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.1"
+version          "0.1.0"


### PR DESCRIPTION
Adding the header option broke some of my runs.  This minor change will allow backward compatibility.  

Thx. 
MD
