### PR TITLE
Chef::Config[:file_backup_path] may not exist on brand new Chef nodes

### DIFF
--- a/providers/extract.rb
+++ b/providers/extract.rb
@@ -30,6 +30,10 @@ action :extract do
   basename = ::File.basename(r.name)
   local_archive = "#{r.download_dir}/#{basename}"
 
+  directory r.download_dir do
+    recursive true
+  end
+
   remote_file basename do
     source r.name
     headers r.headers


### PR DESCRIPTION
This is a clean re-submit of PR#12 -- https://github.com/cramerdev/tar-cookbook/pull/12.

When download_dir uses specified default "Chef::Config[:file_backup_path]", it does not exist on initial chef-client runs.  In cases where file_backup_path has been altered by client.rb, the parent dirs may not exist.  This fix ensures we have a place to download our remote archive files.
