### PR TITLE
add support for encrypted tar files

### DIFF
--- a/providers/extract.rb
+++ b/providers/extract.rb
@@ -59,7 +59,18 @@ end
 def extract_tar(local_archive, r)
   execute "extract #{local_archive}" do
     flags = r.tar_flags ? r.tar_flags.join(' ') : ''
-    command "tar xf#{r.compress_char} #{local_archive} #{flags}"
+    extract_command = "tar xf#{r.compress_char} #{local_archive} #{flags}"
+
+    armor_flag = ""
+    if r.encryption_armor 
+       armor_flag = "-a"
+    end 
+    
+    if r.encryption_key_source != nil
+      extract_command = "openssl enc #{armor_flag} -d -pass #{r.encryption_key_source} -#{r.encryption_algorithm} -in #{local_archive} | tar xf#{r.compress_char} - #{flags}" 
+    end
+
+    command extract_command
     cwd r.target_dir
     creates r.creates
     group  r.group

--- a/resources/extract.rb
+++ b/resources/extract.rb
@@ -36,5 +36,8 @@ attribute :creates,        :kind_of => String
 attribute :compress_char,  :kind_of => String, :default => 'z'
 attribute :tar_flags,      :kind_of => Array,  :default => []
 attribute :user,           :kind_of => String, :default => 'root'
+attribute :encryption_key_source, :kind_of => String
+attribute :encryption_algorithm, :kind_of => String, :default => 'aes-256-cbc'
+attribute :encryption_armor, :kind_of => [TrueClass, FalseClass], :default => true
 
 default_action :extract


### PR DESCRIPTION
I've added a slight change to allow encrypted tar files to be used. I'm using this to handle artifacts which I'm storing in online/cloud storage services.
