### PR TITLE
Change deprecated method

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,5 +1,5 @@
 if defined?(ChefSpec)
-  ChefSpec::Runner.define_runner_method :tar_extract
+  ChefSpec.define_matcher :tar_extract
 
   def install_tar_package(source)
     ChefSpec::Matchers::ResourceMatcher.new(:tar_package, :install, source)


### PR DESCRIPTION
This change gets rid of the deprecated method spam for ChefSpec::Runner.define_runner_method

https://github.com/sethvargo/chefspec/blob/master/CHANGELOG.md#410-october-12-2014
