### PR TITLE
Fixing unused source attribute bug

### DIFF
--- a/resources/package.rb
+++ b/resources/package.rb
@@ -40,7 +40,7 @@ action :install do
   src_dir = r.source_directory
 
   remote_file basename do
-    source r.name
+    source r.source
     path "#{src_dir}/#{basename}"
     backup false
     headers r.headers unless r.headers.nil?


### PR DESCRIPTION
I should have filed a proper issue with a proper pull request, but sadly have no time.
Current cookbook version doesn't actually use source attribute, so users are forced to use resource name instead (which i'd like to avoid).
In case this pull request needs anything else - e.g. tests, clarification or something - let me know and don't merge yet, i really don't have any time now but should have more later (i hope!). I'm totally OK if this will be closed by another person's PR with proper testing / clarification / etc.
