### PR TITLE
Remove user requirement and default fallback to 'root'

### DIFF
--- a/resources/extract.rb
+++ b/resources/extract.rb
@@ -26,13 +26,13 @@
 property :source,                String, name_property: true
 property :checksum,              String
 property :download_dir,          String, default: Chef::Config[:file_cache_path]
-property :group,                 String, default: 'root'
+property :group,                 [String, nil], default: 'root'
 property :mode,                  String, default: '0755'
 property :target_dir,            String
 property :creates,               String
 property :compress_char,         String, default: 'z'
 property :tar_flags,             [String, Array], default: []
-property :user,                  String, default: 'root'
+property :user,                  [String, nil], default: 'root'
 property :headers,               Hash
 property :use_etag,              [true, false], default: true
 property :use_last_modified,     [true, false], default: true


### PR DESCRIPTION
### Description

Windows doesn't have root users so this cookbook always fail on windows: 
```
    Mixlib::ShellOut::InvalidCommandOption
    --------------------------------------
    execute[extract c:\chef\local-mode-cache\cache/bestx-fix-client-app.tar.gz] (c:/chef/local-mode-cache/cache/cookbook
s/tar/resources/extract.rb line 83) had an error: Mixlib::ShellOut::InvalidCommandOption: You must supply both a usernam
e and password when supplying a user in windows
```

and the `password` are not passed to resource execute, so it always fail.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
