### PR TITLE
Add support for FreeBSD

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,7 +18,7 @@ platforms:
   - name: debian-8
   - name: debian-9
   - name: fedora-26
-  - name: opensuse-leap-42
+  - name: opensuse-leap-42.2
   - name: ubuntu-14.04
   - name: ubuntu-16.04
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,8 @@ platforms:
   - name: opensuse-leap-42.2
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: freebsd-10
+  - name: freebsd-11
 
 suites:
 - name: resources

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs tar and two resources to manage remote tar packages'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '2.1.1'
 
-%w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon zlinux).each do |os|
+%w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon zlinux freebsd).each do |os|
   supports os
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,4 +19,4 @@
 # limitations under the License.
 #
 
-package 'tar'
+package 'tar' unless platform_family?('freebsd')

--- a/resources/extract.rb
+++ b/resources/extract.rb
@@ -26,7 +26,7 @@
 property :source,                String, name_property: true
 property :checksum,              String
 property :download_dir,          String, default: Chef::Config[:file_cache_path]
-property :group,                 String, default: 'root'
+property :group,                 String, default: node['root_group']
 property :mode,                  String, default: '0755'
 property :target_dir,            String
 property :creates,               String

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -39,6 +39,10 @@ action :install do
   dirname = basename.chomp('.tar.gz') # Assuming .tar.gz
   src_dir = r.source_directory
 
+  directory src_dir do
+    recursive true
+  end
+
   remote_file basename do
     source r.name
     path "#{src_dir}/#{basename}"

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -64,7 +64,7 @@ action :install do
 
   execute "compile & install #{dirname}" do
     flags = [r.prefix ? "--prefix=#{r.prefix}" : nil, *r.configure_flags].compact.join(' ')
-    command "./configure --quiet #{flags} && make --quiet && make --quiet install"
+    command "./configure --quiet #{flags} && make -s && make -s install"
     cwd "#{src_dir}/#{dirname}"
     creates r.creates
   end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -11,12 +11,12 @@ include_recipe 'build-essential::default'
 
 package 'ncurses-devel' if platform_family?('suse') # needed for nano compile
 
-tar_package 'https://www.nano-editor.org/dist/v2.7/nano-2.7.4.tar.gz' do
+tar_package 'https://www.nano-editor.org/dist/v2.8/nano-2.8.7.tar.gz' do
   prefix '/usr/local'
   creates '/usr/local/bin/nano'
 end
 
-tar_extract 'https://www.nano-editor.org/dist/v2.7/nano-2.7.4.tar.gz' do
+tar_extract 'https://www.nano-editor.org/dist/v2.8/nano-2.8.7.tar.gz' do
   target_dir '/usr/local'
   creates '/opt/myapp/mycode/lib'
   tar_flags ['-P', '--strip-components 1']


### PR DESCRIPTION
### Description

Add support for FreeBSD.  
Tests run in Chef-DK (Vagrant/VirtualBox) all pass, no dokken image is available though so Travis testing for FreeBSD is not enabled.

### Issues Resolved

#42 
 
### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
