### PR TITLE
Fix tar_extract to use the source property

### DIFF
--- a/resources/extract.rb
+++ b/resources/extract.rb
@@ -54,7 +54,7 @@ action :extract do
   end
 
   remote_file basename do
-    source r.name
+    source r.source
     checksum r.checksum
     path local_archive
     backup false


### PR DESCRIPTION
### Description

Fix bug: tar_extract source property don't work.

### Check List

- [/] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [/] New functionality includes testing.
- [/] New functionality has been documented in the README if applicable
- [/] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
