### PR TITLE
Add a tar_binary option to tar_extract and tar_package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The `tar_package` resource provides an easy way to download remote files and com
 - `creates`: prevent the command from running when the specified file already exists.
 - `configure_flags`: Array of additional flags to be passed to `./configure`.
 - `archive_name`: Specify a different name for the downloaded archive. Use it if the directory name inside the tar file is different than the name defined in the URL. Additionally, `tar_package` supports most `remote_file` [attributes](https://docs.chef.io/chef/resources.html#remote-file).
+- `tar_binary`: Specify the path to the tar binary, if "tar" is insufficient.
 
 #### Example
 
@@ -66,6 +67,7 @@ The `tar_extract` resource provides an easy way to extract tar files from downlo
 - `tar_flags`: Array of additional flags to be passed to tar xzf command.
 - `group`: Group name or group ID to extract the archive under. If set to non-root group, point to a `download_dir` the group has permission to access.
 - `user`: User name or user ID to extract the archive under. If set to non-root user, point to a `download_dir` the user has permission to access. Additionally, `tar_extract` supports most `remote_file` [attributes](https://docs.chef.io/chef/resources.html#remote-file).
+- `tar_binary`: Specify the path to the tar binary, if "tar" is insufficient.
 
 #### Example
 

--- a/resources/extract.rb
+++ b/resources/extract.rb
@@ -31,6 +31,7 @@ property :mode,                  String, default: '0755'
 property :target_dir,            String
 property :creates,               String
 property :compress_char,         String, default: 'z'
+property :tar_binary,            String, default: 'tar'
 property :tar_flags,             [String, Array], default: []
 property :user,                  String, default: 'root'
 property :headers,               Hash
@@ -87,7 +88,7 @@ action_class do
               else
                 r.tar_flags.join(' ')
               end
-      command "tar xf#{r.compress_char} #{local_archive.shellescape} #{flags}"
+      command "#{r.tar_binary} xf#{r.compress_char} #{local_archive.shellescape} #{flags}"
       cwd r.target_dir
       creates r.creates
       group  r.group

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -24,6 +24,7 @@ property :headers,               Hash,   default: {}
 property :prefix,                String
 property :source_directory,      String, default: '/usr/local/src'
 property :creates,               String
+property :tar_binary,            String, default: 'tar'
 property :configure_flags,       Array, default: []
 property :archive_name,          String
 property :headers,               Hash
@@ -57,7 +58,7 @@ action :install do
   end
 
   execute "extract #{basename}" do
-    command "tar xfz #{basename}"
+    command "#{r.tar_binary} xfz #{basename}"
     cwd src_dir
     creates "#{src_dir}/#{dirname}"
   end


### PR DESCRIPTION
### Description

The resources didn't allow for specifying the path to the specific tar binary. This is a problem on operating systems with non-GNU `tar`, as `tar` and `gtar` will take different parameters, and `tar_flags` can thus break.

### Issues Resolved

No issue existed for this.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
