### PR TITLE
Fixing archive_name attribute

### DIFF
--- a/resources/package.rb
+++ b/resources/package.rb
@@ -36,8 +36,9 @@ property :manage_symlink_source, [true, false]
 
 action :install do
   r = new_resource
-  basename = r.archive_name || ::File.basename(r.name)
-  dirname = basename.chomp('.tar.gz') # Assuming .tar.gz
+  basename = ::File.basename(r.name)
+  dirname = r.archive_name || ::File.basename(r.name)
+  dirname = dirname.chomp('.tar.gz') # Assuming .tar.gz
   src_dir = r.source_directory
 
   directory src_dir do


### PR DESCRIPTION
Setting the archive_name prevented the archive from being downloaded. The only time the archive_name is needed is after the tar has been downloaded and extracted. archive_name now just changes the dirname variable.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
