### PR TITLE
Target_dir of tar_extract is created with the owner and group of the resource.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Installs tar and two resources to manage remote tar packages'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.2.0'
+version '2.3.0'
 
 %w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon zlinux freebsd).each do |os|
   supports os

--- a/resources/extract.rb
+++ b/resources/extract.rb
@@ -81,7 +81,10 @@ end
 
 action_class do
   def extract_tar(local_archive, r)
-    directory r.target_dir
+    directory r.target_dir do
+      group r.group
+      owner r.user
+    end
     execute "extract #{local_archive}" do
       flags = if r.tar_flags.is_a?(String)
                 r.tar_flags


### PR DESCRIPTION
### Description

Target_dir of tar_extract is created with the owner and group of the resource.

### Issues Resolved

Fixes #62.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
