### PR TITLE
Enable auto-detection of compression format

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The `tar_extract` resource provides an easy way to extract tar files from downlo
 - `target_dir`: Directory to extract into, e.g. tar xzf -C (target_dir)
 - `download_dir`: Directory to which tarball is downloaded (defaults to chef cache which requires root `group` and `user`).
 - `creates`: prevent the command from running when the specified file already exists.
-- `compress_char`: Flag for compression type, such as `z` for `gzip`. `man tar` for options.
+- `compress_char`: Flag for compression type, such as `z` for `gzip`. `man tar` for options. Defaults to empty string for auto-detection.
 - `tar_flags`: Array of additional flags to be passed to tar xzf command.
 - `group`: Group name or group ID to extract the archive under. If set to non-root group, point to a `download_dir` the group has permission to access.
 - `user`: User name or user ID to extract the archive under. If set to non-root user, point to a `download_dir` the user has permission to access. Additionally, `tar_extract` supports most `remote_file` [attributes](https://docs.chef.io/chef/resources.html#remote-file).

--- a/resources/extract.rb
+++ b/resources/extract.rb
@@ -30,7 +30,7 @@ property :group,                 String, default: node['root_group']
 property :mode,                  String, default: '0755'
 property :target_dir,            String
 property :creates,               String
-property :compress_char,         String, default: 'z'
+property :compress_char,         String, default: ''
 property :tar_binary,            String, default: 'tar'
 property :tar_flags,             [String, Array], default: []
 property :user,                  String, default: 'root'


### PR DESCRIPTION
### Description

The `tar_extract` module is hard-coded to assume that tarballs are also gzipped. This notably does not describe a plain tar file. This PR changes the default value for `compress_char` from `'z'` to `''` so that tar will auto-detect the compression format (or no compression) and act accordingly.

Reading online, I believe the primary potential for problems is that GNU tar does not successfully autodetect compression format from `stdin` when using pipes. BSD tar does. I don't believe that applies to this cookbook.

### Issues Resolved

#52

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
